### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python main.py"

--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@
 
 Ended up having to rewrite a good portion of it, so I've improved quite a bit of it.  Now with awesome HP/MP bars, multiple enemies and party members, and items.
 
+[![Run on Repl.it](https://repl.it/badge/github/nickgermaine/python_text_battle)](https://repl.it/github/nickgermaine/python_text_battle)
+
 ![Alt text](/images/rpgbattle-screen.png?raw=true "2017 update")


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@joshwood/pythontextbattle).